### PR TITLE
check for variants of baseline parameter in config

### DIFF
--- a/launch/zed_cpu_ros.launch
+++ b/launch/zed_cpu_ros.launch
@@ -2,7 +2,7 @@
 <arg name="config_file_location" default="$(find zed_cpu_ros)/config/SN1267.conf"/>
 <arg name="camera_namespace" default="camera"/>
 
-<node pkg="zed_cpu_ros" type="zed_cpu_ros" name="zed_cpu_ros_node" output="screen" ns="$(arg camera_namespace)">
+<node pkg="zed_cpu_ros" type="zed_cpu_ros" name="zed_cpu_ros_node" output="screen" ns="$(arg camera_namespace)" required="true">
 	<param name="resolution" value="2"/>
 	<param name="frame_rate" value="30"/>
 	<param name="config_file_location" value="$(arg config_file_location)"/>


### PR DESCRIPTION
There are config files that have the parameter string `Baseline` instead of `BaseLine`.
See http://calib.stereolabs.com/?SN=4353 for an example.

I included a fix that checks which variant of the baseline parameter is present and loads accordingly.

Furthermore, I marked the `zed_cpu_ros_node` as required in the launch file such that roslaunch kills all other nodes if an error occurs in this node.