### PR TITLE
[FIX] CameraInfo Height Width

### DIFF
--- a/src/zed_cpu_ros.cpp
+++ b/src/zed_cpu_ros.cpp
@@ -278,15 +278,23 @@ public:
     {
       case 0:
         reso_str = "2K";
+        width_ = 2208;
+        height_ = 1242;
         break;
       case 1:
         reso_str = "FHD";
+        width_ = 1920;
+        height_ = 1080;
         break;
       case 2:
         reso_str = "HD";
+        width_ = 1270;
+        height_ = 720;
         break;
       case 3:
         reso_str = "VGA";
+        width_ = 640;
+        height_ = 360;
         break;
     }
     // left value


### PR DESCRIPTION
Adding Height and Width definitions to the switch case in ZedCameraROS. This populates the CameraInfo messages for the cameras, which are otherwise set to 0. Though width_ and height_ are variables which are instantiated and referenced, they are never assigned a value in the ZedCameraROS class. The values cannot be inherited either as they are private within StereoCamera.


Thank you for writing this package :)